### PR TITLE
configured stack to use midstream images

### DIFF
--- a/examples/values-ez.yaml
+++ b/examples/values-ez.yaml
@@ -181,6 +181,34 @@ scaffold:
           registry: quay.io
           repository: securesign/cloudsqlproxy
           version: v0.6.4
+      image:
+        registry: quay.io
+        repository: securesign/trillian-db
+        version: v1.5.2
+        pullPolicy: IfNotPresent
+      args: []
+      securityContext:
+        fsGroup: 0
+      livenessProbe:
+        exec:
+          command:
+          - mysqladmin
+          - ping
+          - -h
+          - localhost
+          - -u
+          - $(MYSQL_USER)
+          - -p$(MYSQL_PASSWORD)
+      readinessProbe:
+        exec:
+          command:
+          - mysqladmin
+          - ping
+          - -h
+          - localhost
+          - -u
+          - $(MYSQL_USER)
+          - -p$(MYSQL_PASSWORD)
   tuf:
     namespace:
       create: false

--- a/examples/values-ez.yaml
+++ b/examples/values-ez.yaml
@@ -32,6 +32,12 @@ scaffold:
   ctlog:
     namespace:
       create: false
+    server:
+      image:
+        registry: quay.io
+        repository: securesign/ct_server
+        version: v0.6.4
+        pullPolicy: IfNotPresent
     createctconfig:
       backoffLimit: 30
       enabled: true
@@ -41,13 +47,34 @@ scaffold:
           repository: ubi9/ubi-minimal
           version: latest
           imagePullPolicy: IfNotPresent
+      image:
+        registry: quay.io
+        repository: securesign/createctconfig
+        version: v0.6.4
+        pullPolicy: IfNotPresent
+    createtree:
+      image:
+        registry: quay.io
+        repository: securesign/createtree
+        version: v0.6.4
+        pullPolicy: IfNotPresent
   fulcio:
     namespace:
       name: fulcio-system
       create: false
     createcerts:
       enabled: true
+      image:
+        registry: quay.io
+        repository: securesign/createcerts
+        version: v0.6.4
+        pullPolicy: IfNotPresent
     server:
+      image:
+        registry: quay.io
+        repository: securesign/fulcio
+        version: v1.4.0
+        pullPolicy: IfNotPresent
       secret: fulcio-secret-rh
       ingress:
         http:
@@ -72,6 +99,11 @@ scaffold:
       namespace: rekor-system
       create: false
     server:
+      image:
+        registry: quay.io
+        repository: securesign/rekor-server
+        version: v1.2.2
+        pullPolicy: IfNotPresent
       signer: /key/private
       signerFileSecretOptions:
         secretName: rekor-private-key
@@ -86,10 +118,27 @@ scaffold:
           - host: rekor.apps.rosa.p9esn-qgkm3-wkk.o7au.p3.openshiftapps.com
             path: /
           
+    createtree:
+      image:
+        registry: quay.io
+        repository: securesign/createtree
+        version: v0.6.4
+        pullPolicy: IfNotPresent
+    backfillredis:
+      image:
+        registry: quay.io
+        repository: securesign/backfill-redis
+        version: v1.2.2
+        pullPolicy: IfNotPresent
   trillian:
     namespace:
       create: false
     createdb:
+      image:
+        registry: quay.io
+        repository: securesign/createdb
+        version: v0.6.4
+        pullPolicy: IfNotPresent
     initContainerImage:
       netcat:
         registry: quay.io
@@ -114,6 +163,24 @@ scaffold:
         pullPolicy: IfNotPresent
         version: latest
 
+    logSigner:
+      image:
+        registry: quay.io
+        repository: securesign/trillian_log_signer
+        version: v1.2.2
+        pullPolicy: IfNotPresent
+    logServer:
+      image:
+        registry: quay.io
+        repository: securesign/trillian_log_server
+        version: v1.2.2
+        pullPolicy: IfNotPresent
+    mysql:
+      gcp:
+        scaffoldSQLProxy:
+          registry: quay.io
+          repository: securesign/cloudsqlproxy
+          version: v0.6.4
   tuf:
     namespace:
       create: false
@@ -131,8 +198,8 @@ scaffold:
             path: /
     deployment:
       registry: quay.io
-      repository: ablock/tuf-server
-      version: "sha256:c4f534807b331e97b107d908b7e0cf14a896399bc372bca6a2c7e4f6d730807c"
+      repository: securesign/tuf/server
+      version: latest
 
   copySecretJob:
     enabled: true

--- a/examples/values-ez.yaml
+++ b/examples/values-ez.yaml
@@ -36,7 +36,7 @@ scaffold:
       image:
         registry: quay.io
         repository: securesign/ct_server
-        version: v0.6.4
+        version: sha256:fa5a9a55884d09b7d3fc1d2390087f8344962398d90234958ca7424354c6909e
         pullPolicy: IfNotPresent
     createctconfig:
       backoffLimit: 30
@@ -45,18 +45,18 @@ scaffold:
         curl:
           registry: registry.access.redhat.com
           repository: ubi9/ubi-minimal
-          version: latest
+          version: sha256:dc02c6aa8199beb8ed13312d7116a94aa87b5412886bbe358845d3f0626c0f1e
           imagePullPolicy: IfNotPresent
       image:
         registry: quay.io
         repository: securesign/createctconfig
-        version: v0.6.4
+        version: sha256:1888f625d93618e32766e712f94e148f72fb82b11604001cd98ea6300a9197be
         pullPolicy: IfNotPresent
     createtree:
       image:
         registry: quay.io
         repository: securesign/createtree
-        version: v0.6.4
+        version: sha256:c03cdc797e8d248bfa7371b34b1eda582702e5386fdbb543e5a121afae255fb7
         pullPolicy: IfNotPresent
   fulcio:
     namespace:
@@ -67,13 +67,13 @@ scaffold:
       image:
         registry: quay.io
         repository: securesign/createcerts
-        version: v0.6.4
+        version: sha256:cc10d4f86a893de36e6a269558612b1343dc64c359b927cfcc77ba617eab8283
         pullPolicy: IfNotPresent
     server:
       image:
         registry: quay.io
         repository: securesign/fulcio
-        version: v1.4.0
+        version: sha256:9239e56419073d57bba2ec217c0cf64499b7d4e686a875394d34a802ad99fbad
         pullPolicy: IfNotPresent
       secret: fulcio-secret-rh
       ingress:
@@ -102,7 +102,7 @@ scaffold:
       image:
         registry: quay.io
         repository: securesign/rekor-server
-        version: v1.2.2
+        version: sha256:90797567a064e7b7a41fde208c8468decd11b6b9bab8ed4ab60139c8667600db
         pullPolicy: IfNotPresent
       signer: /key/private
       signerFileSecretOptions:
@@ -122,13 +122,13 @@ scaffold:
       image:
         registry: quay.io
         repository: securesign/createtree
-        version: v0.6.4
+        version: sha256:c03cdc797e8d248bfa7371b34b1eda582702e5386fdbb543e5a121afae255fb7
         pullPolicy: IfNotPresent
     backfillredis:
       image:
         registry: quay.io
         repository: securesign/backfill-redis
-        version: v1.2.2
+        version: sha256:e2cecc21e04f7234dd46651b8cba6a076d869197aa84044404bc08339d6e4913
         pullPolicy: IfNotPresent
   trillian:
     namespace:
@@ -137,17 +137,17 @@ scaffold:
       image:
         registry: quay.io
         repository: securesign/createdb
-        version: v0.6.4
+        version: sha256:19917392e462b0dcf9550441ec0da9518b4666de28fb7e992c692b624569488e
         pullPolicy: IfNotPresent
     initContainerImage:
       netcat:
         registry: quay.io
         repository: securesign/netcat
-        version: v1.0.0
+        version: sha256:b07e50992406ec494abaf2e32d6184f947735074503d6842b4f98240846dc705
       curl:
         registry: registry.access.redhat.com
         repository: ubi9/ubi-minimal
-        version: latest
+        version: sha256:dc02c6aa8199beb8ed13312d7116a94aa87b5412886bbe358845d3f0626c0f1e
         imagePullPolicy: IfNotPresent
     redis:
       args:
@@ -161,30 +161,29 @@ scaffold:
         repository: rhel9/redis-6
         version: "sha256:031a5a63611e1e6a9fec47492a32347417263b79ad3b63bcee72fc7d02d64c94"
         pullPolicy: IfNotPresent
-        version: latest
 
     logSigner:
       image:
         registry: quay.io
         repository: securesign/trillian_log_signer
-        version: v1.2.2
+        version: sha256:ba8d467c38c1eb6a24f843b855e6b01fd5b524d7db45a82b4092a681b561c143
         pullPolicy: IfNotPresent
     logServer:
       image:
         registry: quay.io
         repository: securesign/trillian_log_server
-        version: v1.2.2
+        version: sha256:7e4e931b0141d82034700d7aab113d5b1aab8b2af79fbd254a7a5958cd601969
         pullPolicy: IfNotPresent
     mysql:
       gcp:
         scaffoldSQLProxy:
           registry: quay.io
           repository: securesign/cloudsqlproxy
-          version: v0.6.4
+          version: sha256:6ebd895c0d9896d27185d5e44e2fddd0d00733c5417646b5b239ecfd33bc9bdb
       image:
         registry: quay.io
         repository: securesign/trillian-db
-        version: v1.5.2
+        version: sha256:090e44f8982d66d21c6dc74eb3c0ab3c17e43f22f11731f2e15463f39f811c4a
         pullPolicy: IfNotPresent
       args: []
       securityContext:
@@ -227,7 +226,7 @@ scaffold:
     deployment:
       registry: quay.io
       repository: securesign/tuf/server
-      version: latest
+      version: sha256:b1cbb379f5c4b315bc5a7d7a37865ab61669a0a07002b6920374ebae3b37699c
 
   copySecretJob:
     enabled: true

--- a/examples/values-sigstore-openshift.yaml
+++ b/examples/values-sigstore-openshift.yaml
@@ -65,13 +65,13 @@ scaffold:
       image:
         registry: quay.io
         repository: securesign/createcerts
-        version: v0.6.4
+        version: sha256:cc10d4f86a893de36e6a269558612b1343dc64c359b927cfcc77ba617eab8283
         pullPolicy: IfNotPresent
     server:
       image:
         registry: quay.io
         repository: securesign/fulcio
-        version: v1.4.0
+        version: sha256:9239e56419073d57bba2ec217c0cf64499b7d4e686a875394d34a802ad99fbad
         pullPolicy: IfNotPresent
       secret: fulcio-secret-rh
       ingress:
@@ -96,7 +96,7 @@ scaffold:
       image:
         registry: quay.io
         repository: securesign/rekor-server
-        version: v1.2.2
+        version: sha256:90797567a064e7b7a41fde208c8468decd11b6b9bab8ed4ab60139c8667600db
         pullPolicy: IfNotPresent
       ingress:
         className: ""
@@ -115,13 +115,13 @@ scaffold:
       image:
         registry: quay.io
         repository: securesign/createtree
-        version: v0.6.4
+        version: sha256:c03cdc797e8d248bfa7371b34b1eda582702e5386fdbb543e5a121afae255fb7
         pullPolicy: IfNotPresent
     backfillredis:
       image:
         registry: quay.io
         repository: securesign/backfill-redis
-        version: v1.2.2
+        version: sha256:e2cecc21e04f7234dd46651b8cba6a076d869197aa84044404bc08339d6e4913
         pullPolicy: IfNotPresent
   tuf:
     namespace:
@@ -141,7 +141,7 @@ scaffold:
     deployment:
       registry: quay.io
       repository: securesign/tuf/server
-      version: latest
+      version: sha256:b1cbb379f5c4b315bc5a7d7a37865ab61669a0a07002b6920374ebae3b37699c
   ctlog:
     namespace:
       create: false
@@ -149,7 +149,7 @@ scaffold:
       image:
         registry: quay.io
         repository: securesign/ct_server
-        version: v0.6.4
+        version: sha256:fa5a9a55884d09b7d3fc1d2390087f8344962398d90234958ca7424354c6909e
         pullPolicy: IfNotPresent
     createctconfig:
       backoffLimit: 30
@@ -158,18 +158,18 @@ scaffold:
         curl:
           registry: registry.access.redhat.com
           repository: ubi9/ubi-minimal
-          version: latest
+          version: sha256:dc02c6aa8199beb8ed13312d7116a94aa87b5412886bbe358845d3f0626c0f1e
           imagePullPolicy: IfNotPresent
       image:
         registry: quay.io
         repository: securesign/createctconfig
-        version: v0.6.4
+        version: sha256:1888f625d93618e32766e712f94e148f72fb82b11604001cd98ea6300a9197be
         pullPolicy: IfNotPresent
     createtree:
       image:
         registry: quay.io
         repository: securesign/createtree
-        version: v0.6.4
+        version: sha256:c03cdc797e8d248bfa7371b34b1eda582702e5386fdbb543e5a121afae255fb7
         pullPolicy: IfNotPresent
 
   trillian:
@@ -179,17 +179,17 @@ scaffold:
       image:
         registry: quay.io
         repository: securesign/createdb
-        version: v0.6.4
+        version: sha256:19917392e462b0dcf9550441ec0da9518b4666de28fb7e992c692b624569488e
         pullPolicy: IfNotPresent
     initContainerImage:
       netcat:
         registry: quay.io
         repository: securesign/netcat
-        version: v1.0.0
+        version: sha256:b07e50992406ec494abaf2e32d6184f947735074503d6842b4f98240846dc705
       curl:
         registry: registry.access.redhat.com
         repository: ubi9/ubi-minimal
-        version: latest
+        version: sha256:dc02c6aa8199beb8ed13312d7116a94aa87b5412886bbe358845d3f0626c0f1e
         imagePullPolicy: IfNotPresent
     redis:
       args:
@@ -203,29 +203,28 @@ scaffold:
         repository: rhel9/redis-6
         version: "sha256:031a5a63611e1e6a9fec47492a32347417263b79ad3b63bcee72fc7d02d64c94"
         pullPolicy: IfNotPresent
-        version: latest
     logSigner:
       image:
         registry: quay.io
         repository: securesign/trillian_log_signer
-        version: v1.2.2
+        version: sha256:ba8d467c38c1eb6a24f843b855e6b01fd5b524d7db45a82b4092a681b561c143
         pullPolicy: IfNotPresent
     logServer:
       image:
         registry: quay.io
         repository: securesign/trillian_log_server
-        version: v1.2.2
+        version: sha256:7e4e931b0141d82034700d7aab113d5b1aab8b2af79fbd254a7a5958cd601969
         pullPolicy: IfNotPresent
     mysql:
       gcp:
         scaffoldSQLProxy:
           registry: quay.io
           repository: securesign/cloudsqlproxy
-          version: v0.6.4
+          version: sha256:6ebd895c0d9896d27185d5e44e2fddd0d00733c5417646b5b239ecfd33bc9bdb
       image:
         registry: quay.io
         repository: securesign/trillian-db
-        version: v1.5.2
+        version: sha256:090e44f8982d66d21c6dc74eb3c0ab3c17e43f22f11731f2e15463f39f811c4a
         pullPolicy: IfNotPresent
       args: []
       securityContext:

--- a/examples/values-sigstore-openshift.yaml
+++ b/examples/values-sigstore-openshift.yaml
@@ -222,6 +222,34 @@ scaffold:
           registry: quay.io
           repository: securesign/cloudsqlproxy
           version: v0.6.4
+      image:
+        registry: quay.io
+        repository: securesign/trillian-db
+        version: v1.5.2
+        pullPolicy: IfNotPresent
+      args: []
+      securityContext:
+        fsGroup: 0
+      livenessProbe:
+        exec:
+          command:
+          - mysqladmin
+          - ping
+          - -h
+          - localhost
+          - -u
+          - $(MYSQL_USER)
+          - -p$(MYSQL_PASSWORD)
+      readinessProbe:
+        exec:
+          command:
+          - mysqladmin
+          - ping
+          - -h
+          - localhost
+          - -u
+          - $(MYSQL_USER)
+          - -p$(MYSQL_PASSWORD)
 
 
   copySecretJob:

--- a/examples/values-sigstore-openshift.yaml
+++ b/examples/values-sigstore-openshift.yaml
@@ -62,7 +62,17 @@ scaffold:
       create: false
     createcerts:
       enabled: false
+      image:
+        registry: quay.io
+        repository: securesign/createcerts
+        version: v0.6.4
+        pullPolicy: IfNotPresent
     server:
+      image:
+        registry: quay.io
+        repository: securesign/fulcio
+        version: v1.4.0
+        pullPolicy: IfNotPresent
       secret: fulcio-secret-rh
       ingress:
         http:
@@ -83,6 +93,11 @@ scaffold:
     namespace:
       create: false
     server:
+      image:
+        registry: quay.io
+        repository: securesign/rekor-server
+        version: v1.2.2
+        pullPolicy: IfNotPresent
       ingress:
         className: ""
         annotations:
@@ -96,6 +111,18 @@ scaffold:
         secretMountPath: /key
         secretMountSubPath: private
         privateKeySecretKey: private
+    createtree:
+      image:
+        registry: quay.io
+        repository: securesign/createtree
+        version: v0.6.4
+        pullPolicy: IfNotPresent
+    backfillredis:
+      image:
+        registry: quay.io
+        repository: securesign/backfill-redis
+        version: v1.2.2
+        pullPolicy: IfNotPresent
   tuf:
     namespace:
       create: false
@@ -111,15 +138,90 @@ scaffold:
         hosts:
           - host: tuf.apps.<OPENSHIFT_BASE_DOMAIN>
             path: /
+    deployment:
+      registry: quay.io
+      repository: securesign/tuf/server
+      version: latest
   ctlog:
     namespace:
       create: false
+    server:
+      image:
+        registry: quay.io
+        repository: securesign/ct_server
+        version: v0.6.4
+        pullPolicy: IfNotPresent
     createctconfig:
       backoffLimit: 30
+      enabled: true
+      initContainerImage:
+        curl:
+          registry: registry.access.redhat.com
+          repository: ubi9/ubi-minimal
+          version: latest
+          imagePullPolicy: IfNotPresent
+      image:
+        registry: quay.io
+        repository: securesign/createctconfig
+        version: v0.6.4
+        pullPolicy: IfNotPresent
+    createtree:
+      image:
+        registry: quay.io
+        repository: securesign/createtree
+        version: v0.6.4
+        pullPolicy: IfNotPresent
 
   trillian:
     namespace:
       create: false
+    createdb:
+      image:
+        registry: quay.io
+        repository: securesign/createdb
+        version: v0.6.4
+        pullPolicy: IfNotPresent
+    initContainerImage:
+      netcat:
+        registry: quay.io
+        repository: securesign/netcat
+        version: v1.0.0
+      curl:
+        registry: registry.access.redhat.com
+        repository: ubi9/ubi-minimal
+        version: latest
+        imagePullPolicy: IfNotPresent
+    redis:
+      args:
+        - /usr/bin/run-redis
+        - --bind
+        - 0.0.0.0
+        - --appendonly
+        - "yes"
+      image:
+        registry: registry.redhat.io
+        repository: rhel9/redis-6
+        version: "sha256:031a5a63611e1e6a9fec47492a32347417263b79ad3b63bcee72fc7d02d64c94"
+        pullPolicy: IfNotPresent
+        version: latest
+    logSigner:
+      image:
+        registry: quay.io
+        repository: securesign/trillian_log_signer
+        version: v1.2.2
+        pullPolicy: IfNotPresent
+    logServer:
+      image:
+        registry: quay.io
+        repository: securesign/trillian_log_server
+        version: v1.2.2
+        pullPolicy: IfNotPresent
+    mysql:
+      gcp:
+        scaffoldSQLProxy:
+          registry: quay.io
+          repository: securesign/cloudsqlproxy
+          version: v0.6.4
 
 
   copySecretJob:


### PR DESCRIPTION
This PR is related to this issue [here](https://github.com/securesign/sigstore-ocp/issues/6) and involves switching the images used in the helm charts from the upstream to the midstream.

## Testing 
1. Pull down this branch.
2. Create a OpenShift cluster, whichever way your prefer.
3. Follow the steps to deploy the charts [here](https://github.com/securesign/sigstore-ocp)
4. Follow the steps to sign and verify [here](https://github.com/securesign/sigstore-ocp/blob/main/sign-verify.md)


## Comments
I was able to verify images using both value files, but there was some things I noticed when looking at the upstream charts. 

In the midstream I believe we are missing two images, That were not able to be swapped out. 
1.  [Here](https://github.com/sigstore/helm-charts/blob/main/charts/rekor/values.yaml#L25) , An image for redis, although I think this can remain the same, just want to make sure.
2. [Here](url) An image for cloudsql, same as above, again not too sure. 

~~Also I was unable to get this [image](https://quay.io/repository/securesign/trillian-db) to work with the stack, so I am going to try and troubleshoot it further.~~