### PR TITLE
Add cosign to helm charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ oc apply --kustomize keycloak/resources # wait until keycloak-system pods are he
 :%s/rosa.*.com/rosa.p9esn-qgkm3-wkk.o7au.p3.openshiftapps.com/g
 ```
 
+* *If you intend to use the cosign pod to sign an image, ensure you configure the BASE_HOSTNAME value in the values.yaml file.*
+```
+cosign:
+  BASE_HOSTNAME: apps.<base_domain>
+```
+
 4.  Run the following:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -172,10 +172,10 @@ oc apply --kustomize keycloak/resources # wait until keycloak-system pods are he
 :%s/rosa.*.com/rosa.p9esn-qgkm3-wkk.o7au.p3.openshiftapps.com/g
 ```
 
-* *If you intend to use the cosign pod to sign an image, ensure you configure the BASE_HOSTNAME value in the values.yaml file.*
+* *If you intend to use the cosign pod to sign an image, ensure you configure the BASE_DOMAIN value in the values-ez.yaml, or values-sigstore-openshift.yaml file.*
 ```
 cosign:
-  BASE_HOSTNAME: apps.<base_domain>
+  BASE_DOMAIN: apps.<base_domain>
 ```
 
 4.  Run the following:

--- a/examples/values-ez.yaml
+++ b/examples/values-ez.yaml
@@ -28,7 +28,7 @@ configs:
         name: rekor-private-key
         private_key_file: "keys-cert/rekor_key.pem"
   cosign:
-    BASE_HOSTNAME: apps.rosa.p9esn-qgkm3-wkk.o7au.p3.openshiftapps.com
+    BASE_DOMAIN: apps.rosa.p9esn-qgkm3-wkk.o7au.p3.openshiftapps.com
 
 scaffold:
   ctlog:

--- a/examples/values-ez.yaml
+++ b/examples/values-ez.yaml
@@ -27,6 +27,8 @@ configs:
       secret:
         name: rekor-private-key
         private_key_file: "keys-cert/rekor_key.pem"
+  cosign:
+    BASE_HOSTNAME: apps.rosa.p9esn-qgkm3-wkk.o7au.p3.openshiftapps.com
 
 scaffold:
   ctlog:

--- a/examples/values-sigstore-openshift.yaml
+++ b/examples/values-sigstore-openshift.yaml
@@ -55,6 +55,9 @@ configs:
           szmI+ON/YItgbv0e5Wu7t9700ujBNfgMhzyO
           -----END CERTIFICATE-----
 
+  cosign:
+    BASE_HOSTNAME: apps.rosa.p9esn-qgkm3-wkk.o7au.p3.openshiftapps.com
+
 scaffold:
   fulcio:
     namespace:

--- a/examples/values-sigstore-openshift.yaml
+++ b/examples/values-sigstore-openshift.yaml
@@ -56,7 +56,7 @@ configs:
           -----END CERTIFICATE-----
 
   cosign:
-    BASE_HOSTNAME: apps.rosa.p9esn-qgkm3-wkk.o7au.p3.openshiftapps.com
+    BASE_DOMAIN: apps.<OPENSHIFT_BASE_DOMAIN>
 
 scaffold:
   fulcio:

--- a/keycloak/resources/sigstore-client.yaml
+++ b/keycloak/resources/sigstore-client.yaml
@@ -16,7 +16,7 @@ spec:
     - profile
     - email
     description: Client for Sigstore authentication
-    directAccessGrantsEnabled: false
+    directAccessGrantsEnabled: true
     implicitFlowEnabled: false
     name: sigstore
     protocol: openid-connect

--- a/templates/cosign-deployment.yaml
+++ b/templates/cosign-deployment.yaml
@@ -17,18 +17,18 @@ spec:
       - name: {{ .Values.configs.cosign.metadata.name }}
         image: "{{ .Values.configs.cosign.image.registry }}/{{ .Values.configs.cosign.image.repository }}:{{ .Values.configs.cosign.image.version }}"
         env:
-        - name: BASE_HOSTNAME
-          value: {{ .Values.configs.cosign.BASE_HOSTNAME }}
+        - name: BASE_DOMAIN
+          value: {{ .Values.configs.cosign.BASE_DOMAIN }}
         - name: KEYCLOAK_REALM
           value: "sigstore"
         - name: FULCIO_URL
-          value: "https://fulcio.$(BASE_HOSTNAME)"
+          value: "https://fulcio.$(BASE_DOMAIN)"
         - name: KEYCLOAK_URL
-          value: "https://keycloak-keycloak-system.$(BASE_HOSTNAME)"
+          value: "https://keycloak-keycloak-system.$(BASE_DOMAIN)"
         - name: REKOR_URL
-          value: "https://rekor.$(BASE_HOSTNAME)"
+          value: "https://rekor.$(BASE_DOMAIN)"
         - name: TUF_URL
-          value: "https://tuf.$(BASE_HOSTNAME)"
+          value: "https://tuf.$(BASE_DOMAIN)"
         - name: KEYCLOAK_OIDC_ISSUER
           value: "$KEYCLOAK_URL/auth/realms/$(KEYCLOAK_REALM)"
         securityContext:

--- a/templates/cosign-deployment.yaml
+++ b/templates/cosign-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.configs.cosign.metadata.name }}
+  namespace: {{ .Values.configs.cosign.namespace }}
+spec:
+  replicas: {{ .Values.configs.cosign.spec.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.configs.cosign.metadata.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.configs.cosign.metadata.name }}
+    spec:
+      containers:
+      - name: {{ .Values.configs.cosign.metadata.name }}
+        image: "{{ .Values.configs.cosign.image.registry }}/{{ .Values.configs.cosign.image.repository }}:{{ .Values.configs.cosign.image.version }}"
+        env:
+        - name: BASE_HOSTNAME
+          value: {{ .Values.configs.cosign.BASE_HOSTNAME }}
+        - name: KEYCLOAK_REALM
+          value: "sigstore"
+        - name: FULCIO_URL
+          value: "https://fulcio.$(BASE_HOSTNAME)"
+        - name: KEYCLOAK_URL
+          value: "https://keycloak-keycloak-system.$(BASE_HOSTNAME)"
+        - name: REKOR_URL
+          value: "https://rekor.$(BASE_HOSTNAME)"
+        - name: TUF_URL
+          value: "https://tuf.$(BASE_HOSTNAME)"
+        - name: KEYCLOAK_OIDC_ISSUER
+          value: "$KEYCLOAK_URL/auth/realms/$(KEYCLOAK_REALM)"
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault

--- a/values.yaml
+++ b/values.yaml
@@ -53,7 +53,7 @@ configs:
       - tuf-secret-copy-job
 
   cosign:
-    BASE_HOSTNAME: apps.<base_domain>
+    BASE_DOMAIN: apps.<base_domain>
     namespace: cosign
     create: true
     rolebindings:

--- a/values.yaml
+++ b/values.yaml
@@ -52,5 +52,21 @@ configs:
       - tuf
       - tuf-secret-copy-job
 
+  cosign:
+    BASE_HOSTNAME: apps.<base_domain>
+    namespace: cosign
+    create: true
+    rolebindings:
+      - cosign
+    metadata:
+      name: cosign
+    spec:
+      replicas: 1
+    image:
+      registry: quay.io
+      repository: securesign/cosign
+      version: v2.1.1
+      pullPolicy: IfNotPresent
+
 rbac:
   clusterrole: system:openshift:scc:anyuid


### PR DESCRIPTION
This PR relates to this issue [here](https://github.com/securesign/sigstore-ocp/issues/10), and involves adding cosign to the midstream helm charts. 

## Testing 
1. Pull down branch 
2. Launch an open shift cluster
3. Deploy helm charts (make sure to configure BASE_HOSTNAME in values.yaml)
4. Try sign and verify an image (follow the updated steps in sign-verify.md if needed)

## Comments
**Important: Should not be merged before this [pr](https://github.com/securesign/image-factory/pull/12)**