### PR TITLE
Add grafana monitoring to helm charts

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -8,3 +8,8 @@ dependencies:
   - name: scaffold
     version: x
     repository: https://sigstore.github.io/helm-charts
+
+  - name: grafana
+    version: x
+    repository: "https://grafana.github.io/helm-charts"
+    condition: grafana.enabled

--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ A good way to tell if things are progressing well is to watch `oc get jobs -A` a
 Once complete, move to the [Sign & Verify document](./sign-verify.md) to test the Sigstore stack. 
 Good Luck!
 
+For real-time analytics through Grafana, please refer to our [enable-grafana-monitoring.md](enable-grafana-monitoring.md) guide.
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/dashboards/sigstore-monitoring.json
+++ b/dashboards/sigstore-monitoring.json
@@ -1,0 +1,393 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "cellHeight": "lg",
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": [
+            "kube_pod_status_phase"
+          ],
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 1,
+        "showHeader": true
+      },
+      "pluginVersion": "10.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "kube_pod_status_phase{namespace=\"$Namespace\"} == 1",
+          "instant": true,
+          "legendFormat": "{{pod}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Pod status",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "keepLabels": [
+              "namespace",
+              "pod",
+              "phase"
+            ]
+          }
+        },
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": false,
+              "kube_pod_status_phase": true,
+              "phase": false,
+              "pod": false,
+              "scaffolding-tuf-tuf-c89d7c455-6nltf": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(pod) (rate(container_cpu_usage_seconds_total{namespace=\"$Namespace\"}[5m]) * 100)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "CPU Usage - {{ pod }}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "CPU Usage",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(pod) (rate(container_memory_usage_bytes{namespace=\"$Namespace\"}[5m]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Memory Usage - {{ pod }}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Memory Usage",
+      "transformations": [],
+      "type": "timeseries"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "sigstore",
+          "value": "sigstore"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace",
+        "multi": false,
+        "name": "Namespace",
+        "options": [
+          {
+            "selected": false,
+            "text": "tuf-system",
+            "value": "tuf-system"
+          },
+          {
+            "selected": false,
+            "text": "trillian-system",
+            "value": "trillian-system"
+          },
+          {
+            "selected": true,
+            "text": "sigstore",
+            "value": "sigstore"
+          },
+          {
+            "selected": false,
+            "text": "rekor-system",
+            "value": "rekor-system"
+          },
+          {
+            "selected": false,
+            "text": "fulcio-system",
+            "value": "fulcio-system"
+          },
+          {
+            "selected": false,
+            "text": "ctlog-system",
+            "value": "ctlog-system"
+          },
+          {
+            "selected": false,
+            "text": "cosign",
+            "value": "cosign"
+          }
+        ],
+        "query": "tuf-system,trillian-system,sigstore,rekor-system,fulcio-system,ctlog-system,cosign",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Sigstore Monitoring",
+  "uid": "b8e5cb61-a672-401c-a406-a5360c8e384a",
+  "version": 1,
+  "weekStart": ""
+}

--- a/dashboards/sigstore-monitoring.json
+++ b/dashboards/sigstore-monitoring.json
@@ -18,6 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": 1,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -46,7 +47,50 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CPU - Usage 24hr avg"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Memory - Usage 24hr avg"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Storage - Usage 24hr avg"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 10,
@@ -68,7 +112,7 @@
           ],
           "show": false
         },
-        "frameIndex": 1,
+        "frameIndex": 0,
         "showHeader": true
       },
       "pluginVersion": "10.1.1",
@@ -81,24 +125,64 @@
           "editorMode": "code",
           "exemplar": false,
           "expr": "kube_pod_status_phase{namespace=\"$Namespace\"} == 1",
+          "format": "table",
           "instant": true,
           "legendFormat": "{{pod}}",
           "range": false,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum by(pod) (rate(container_cpu_usage_seconds_total{namespace=\"$Namespace\"}[5m]) * 100)",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "cpu",
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(pod) (rate(container_memory_usage_bytes{namespace=\"$Namespace\"}[5m]))",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "memory",
+          "range": false,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum by(pod) (avg_over_time(kubelet_volume_stats_used_bytes{namespace=\"$Namespace\"}[24h:]))",
+          "format": "table",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "legendFormat": "memory",
+          "range": false,
+          "refId": "D",
+          "useBackend": false
         }
       ],
       "title": "Pod status",
       "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "keepLabels": [
-              "namespace",
-              "pod",
-              "phase"
-            ]
-          }
-        },
         {
           "id": "merge",
           "options": {}
@@ -107,117 +191,42 @@
           "id": "organize",
           "options": {
             "excludeByName": {
-              "Time": false,
-              "kube_pod_status_phase": true,
-              "phase": false,
-              "pod": false,
-              "scaffolding-tuf-tuf-c89d7c455-6nltf": true
+              "Time": true,
+              "Value #A": true,
+              "__name__": true,
+              "container": true,
+              "endpoint": true,
+              "instance": true,
+              "job": true,
+              "metrics_path": true,
+              "node": true,
+              "persistentvolumeclaim": true,
+              "prometheus": true,
+              "service": true,
+              "source": true,
+              "uid": true
             },
             "indexByName": {},
-            "renameByName": {}
+            "renameByName": {
+              "Value #B": "CPU - Usage 24hr avg",
+              "Value #C": "Memory - Usage 24hr avg",
+              "Value #D": "Storage - Usage 24hr avg"
+            }
           }
         }
       ],
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
       "gridPos": {
-        "h": 12,
-        "w": 12,
+        "h": 1,
+        "w": 24,
         "x": 0,
         "y": 10
       },
-      "id": 7,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "sum by(pod) (rate(container_cpu_usage_seconds_total{namespace=\"$Namespace\"}[5m]) * 100)",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "CPU Usage - {{ pod }}",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "CPU Usage",
-      "transformations": [],
-      "type": "timeseries"
+      "id": 5,
+      "title": "Service Metrics",
+      "type": "row"
     },
     {
       "datasource": {
@@ -227,38 +236,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "mode": "thresholds"
           },
           "mappings": [],
           "thresholds": {
@@ -278,48 +256,52 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 12,
-        "w": 12,
-        "x": 12,
-        "y": 10
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 11
       },
-      "id": 3,
+      "id": 6,
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
+        "textMode": "auto"
       },
+      "pluginVersion": "10.1.1",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(pod) (rate(container_memory_usage_bytes{namespace=\"$Namespace\"}[5m]))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
+          "expr": "rekor_new_entries",
           "instant": false,
-          "legendFormat": "Memory Usage - {{ pod }}",
+          "legendFormat": "__auto",
           "range": true,
-          "refId": "A",
-          "useBackend": false
+          "refId": "A"
         }
       ],
-      "title": "Memory Usage",
-      "transformations": [],
-      "type": "timeseries"
+      "title": "Signature Count",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        }
+      ],
+      "type": "stat"
     }
   ],
-  "refresh": false,
+  "refresh": "",
   "schemaVersion": 38,
   "style": "dark",
   "tags": [],
@@ -328,8 +310,8 @@
       {
         "current": {
           "selected": true,
-          "text": "sigstore",
-          "value": "sigstore"
+          "text": "trillian-system",
+          "value": "trillian-system"
         },
         "hide": 0,
         "includeAll": false,
@@ -343,12 +325,12 @@
             "value": "tuf-system"
           },
           {
-            "selected": false,
+            "selected": true,
             "text": "trillian-system",
             "value": "trillian-system"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "sigstore",
             "value": "sigstore"
           },

--- a/enable-grafana-monitoring.md
+++ b/enable-grafana-monitoring.md
@@ -1,0 +1,43 @@
+# Enabling Grafana Monitoring for this Helm Chart
+
+This guide provides a step-by-step instruction to enable Grafana monitoring in a openshift cluster using Helm charts. Make sure you have Helm and oc command-line tool installed, and you are logged into the cluster.
+
+Note: This guide assumes you are using Helm version 3.11 and OpenShift version 4.12.
+
+## Step 1: Configuring Access Token
+
+Before enabling Grafana monitoring, retrieve an access token from a service account located in the openshift-user-workload-monitoring namespace.
+
+```
+export ACC_TOKEN=$(oc -n openshift-user-workload-monitoring get secrets -o name | grep 'prometheus-user-workload-token-' | xargs -I {} oc -n openshift-user-workload-monitoring get {} -o=jsonpath="{.data.token}" | base64 -d)
+```
+
+This command retrieves the correct access token and sets it to the ACC_TOKEN environmental variable.
+
+## Step 2: Deploying the Helm Chart with Grafana
+
+Run the following command to deploy the Helm charts with Grafana enabled:
+
+```
+helm upgrade -i scaffolding --debug . -n sigstore --create-namespace -f examples/values-ez.yaml --set grafana.enabled=true --set grafana.accToken=$ACC_TOKEN
+```
+
+## Step 3: Accessing the Grafana UI
+
+To find the Grafana UI route, execute:
+
+```
+oc -n sigstore get routes
+```
+
+Or navigate to Networking -> Routes in the sigstore namespace through the OpenShift cluster UI.
+
+Retrieve the admin password for Grafana:
+```
+oc -n sigstore get secrets scaffolding-grafana -o=jsonpath="{.data.admin-password}" | base64 -d
+```
+
+Use `admin` as the username and the retrieved password to log in.
+
+Once logged in, navigate to the dashboard by going to Dashboards -> General -> Sigstore Monitoring.
+

--- a/enable-grafana-monitoring.md
+++ b/enable-grafana-monitoring.md
@@ -12,7 +12,7 @@ Before enabling Grafana monitoring, retrieve an access token from a service acco
 export ACC_TOKEN=$(oc -n openshift-user-workload-monitoring get secrets -o name | grep 'prometheus-user-workload-token-' | xargs -I {} oc -n openshift-user-workload-monitoring get {} -o=jsonpath="{.data.token}" | base64 -d)
 ```
 
-This command retrieves the correct access token and sets it to the ACC_TOKEN environmental variable.
+This command retrieves the correct access token and sets it to the ACC_TOKEN environmental variable.You may want to `echo $ACC_TOKEN` before proceeding to ensure the variable is set if its not the cluster may not be fully provisioned yet.
 
 ## Step 2: Deploying the Helm Chart with Grafana
 

--- a/examples/values-ez.yaml
+++ b/examples/values-ez.yaml
@@ -233,3 +233,40 @@ scaffold:
   copySecretJob:
     enabled: true
     backoffLimit: 1000
+
+grafana:
+  securityContext:
+    runAsUser: 1000760000
+    runAsGroup: 1000760000
+    fsGroup: 1000760000
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - access: proxy
+          isDefault: true
+          jsonData:
+            httpHeaderName1: "Authorization"
+            timeInterval: 5s
+            tlsSkipVerify: true
+          name: Prometheus
+          secureJsonData:
+            httpHeaderValue1: "Bearer {{ .Values.accToken }}"
+          type: prometheus
+          url: "https://thanos-querier-openshift-monitoring.apps.rosa.vdx4u-y9kr4-qi4.pehe.p3.openshiftapps.com"
+  dashboardProviders:
+    dashboardproviders.yaml:
+      apiVersion: 1
+      providers:
+        - name: "sigstore-monitoring"
+          orgId: 1
+          options:
+            path: /var/lib/grafana/dashboards/sigstore-monitoring
+  extraConfigmapMounts:
+    - name: dashboard-configmap
+      mountPath: /var/lib/grafana/dashboards/sigstore-monitoring
+      configMap: grafana-dashboard-configmap
+  ingress:
+    enabled: true
+    hosts:
+      - scaffolding-grafana-sigstore.apps.rosa.vdx4u-y9kr4-qi4.pehe.p3.openshiftapps.com

--- a/templates/grafana-dashboard-configmap.yml
+++ b/templates/grafana-dashboard-configmap.yml
@@ -1,0 +1,11 @@
+{{- if .Values.grafana.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-configmap
+  labels:
+    grafana_dashboard: "1"
+data:
+  sigstore-monitoring.json: |-
+  {{ .Files.Get "dashboards/sigstore-monitoring.json" | nindent 4 }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -70,3 +70,7 @@ configs:
 
 rbac:
   clusterrole: system:openshift:scc:anyuid
+
+grafana:
+  enabled: false
+  accToken: access_token


### PR DESCRIPTION
This pr is related to this [issue](https://issues.redhat.com/projects/SECURESIGN/issues/SECURESIGN-54?filter=allopenissues), and involves enabling monitoring via a grafana dashboard.


## Testing
1. Checkout and pull branch
2. Follow usual steps to deploy stack in the [README](https://github.com/securesign/sigstore-ocp#no-fail-quick-start-in-5-steps)
3. Before deploying the stack checkout the instructions in enable-grafana-monitoring.md
4. Ensure that grafana gets installed and you can view the dashboards

## Comments 
The dashboard in this pr completes everything defined in the jira, If you believe that there should be more in the dashboard please feel free to reach out, or add it yourself. 