### PR TITLE
fix for livenessProbe and readinessProbe

### DIFF
--- a/examples/values-ez.yaml
+++ b/examples/values-ez.yaml
@@ -193,23 +193,15 @@ scaffold:
       livenessProbe:
         exec:
           command:
-          - mysqladmin
-          - ping
-          - -h
-          - localhost
-          - -u
-          - $(MYSQL_USER)
-          - -p$(MYSQL_PASSWORD)
+          - /bin/sh
+          - -c
+          - mysqladmin ping -h localhost -u $MYSQL_USER -p$MYSQL_PASSWORD
       readinessProbe:
         exec:
           command:
-          - mysqladmin
-          - ping
-          - -h
-          - localhost
-          - -u
-          - $(MYSQL_USER)
-          - -p$(MYSQL_PASSWORD)
+          - /bin/sh
+          - -c
+          - mysqladmin ping -h localhost -u $MYSQL_USER -p$MYSQL_PASSWORD
   tuf:
     namespace:
       create: false


### PR DESCRIPTION
Just a small pr, i noticed that when standing up the stack in the logs of the MySQL image in trillian-system namespace there was a constant warning stating that 'mysl'@localhost didn't have access the original command wasn't using the password right 