### PR TITLE
add service monitors for metrics

### DIFF
--- a/templates/cluster-monitoring-resources.yaml
+++ b/templates/cluster-monitoring-resources.yaml
@@ -36,8 +36,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app.kubernetes.io/name: {{ $config.clusterMonitoring.name }}   
-  name: {{ $config.clusterMonitoring.name }}-server-monitor
+    app.kubernetes.io/name: {{ $config.namespace }}   
+  name: {{ $config.namespace }}
   namespace: {{ $config.namespace }}
 spec:
   endpoints:

--- a/templates/cluster-monitoring-resources.yaml
+++ b/templates/cluster-monitoring-resources.yaml
@@ -1,0 +1,53 @@
+{{- range $configKey, $config := .Values.configs }}
+{{- if and $config.clusterMonitoring (eq $config.clusterMonitoring.enabled true) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: {{ $config.namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: {{ $config.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ $config.clusterMonitoring.name }}   
+  name: {{ $config.clusterMonitoring.name }}-server-monitor
+  namespace: {{ $config.namespace }}
+spec:
+  endpoints:
+  {{- range $endpoint := $config.clusterMonitoring.endpoints }}
+  - interval: {{ $endpoint.interval }}
+    port: {{ $endpoint.port }}
+    scheme: {{ $endpoint.scheme }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: scaffolding
+{{- end }}
+{{- end }}

--- a/templates/namespace.yaml
+++ b/templates/namespace.yaml
@@ -5,5 +5,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ $config.namespace }}
+  {{- if and $config.clusterMonitoring (eq $config.clusterMonitoring.enabled true) }}
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  {{- end}}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -23,9 +23,8 @@ configs:
         private_key_file: ""
         root_cert: ""
         root_cert_file: ""
-    clusterMonitoring: 
+    clusterMonitoring:
       enabled: true
-      name: fulcio
       endpoints:
         - interval: 30s
           port: 2112-tcp
@@ -43,9 +42,8 @@ configs:
         name: ""
         private_key: ""
         private_key_file: ""
-    clusterMonitoring: 
+    clusterMonitoring:
       enabled: true
-      name: rekor
       endpoints:
         - interval: 30s
           port: 2112-tcp

--- a/values.yaml
+++ b/values.yaml
@@ -23,6 +23,13 @@ configs:
         private_key_file: ""
         root_cert: ""
         root_cert_file: ""
+    clusterMonitoring: 
+      enabled: true
+      name: fulcio
+      endpoints:
+        - interval: 30s
+          port: 2112-tcp
+          scheme: http
 
   rekor:
     namespace: rekor-system
@@ -36,6 +43,13 @@ configs:
         name: ""
         private_key: ""
         private_key_file: ""
+    clusterMonitoring: 
+      enabled: true
+      name: rekor
+      endpoints:
+        - interval: 30s
+          port: 2112-tcp
+          scheme: http
 
   trillian:
     namespace: trillian-system


### PR DESCRIPTION
This pr adds service monitors, rbac and namespace labels for the rekor-system and fulcio-system namespaces, for future monitoring work.

## Testing 

1. Pull down this pr 
2. Stand up stack as normal
3. Navigate to the Metrics section in the openshitf ui
4. You should be able to query the metrics endpoints exposed by the rekor and fulcio servers