### PR TITLE
Add audience to access token

### DIFF
--- a/keycloak/resources/sigstore-client.yaml
+++ b/keycloak/resources/sigstore-client.yaml
@@ -42,6 +42,7 @@ spec:
         claim.name: aud
         claim.value: sigstore
         id.token.claim: "true"
+        access.token.claim: "true"
         userinfo.token.claim: "true"
       name: audience
       protocol: openid-connect


### PR DESCRIPTION
Fix for the keycloak configuration. The "aud" field is missing from the token requested by 
```
curl -X POST -H "Content-Type: application/x-www-form-urlencoded" \
-d "client_id=<client_id>" \
-d "username=<username>" \
-d "password=<password>" \
-d "grant_type=password" \
-d "scope=openid" \
<oidc_issuer_url>/protocol/openid-connect/token
```
and the sign request fails with
```
ERROR	server/error.go:45	returning with error	{"requestID": "nMNfx_9E", "code": "InvalidArgument", "clientMessage": "There was an error processing the identity token", "error": "oidc: expected audience \"sigstore\" got []"}
```