### PR TITLE
Keycloak resources fix

### DIFF
--- a/keycloak/operator/subscription.yaml
+++ b/keycloak/operator/subscription.yaml
@@ -10,7 +10,6 @@ spec:
   name: rhsso-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: rhsso-operator.7.6.4-opr-002
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup

--- a/keycloak/resources/keycloak.yaml
+++ b/keycloak/resources/keycloak.yaml
@@ -5,9 +5,6 @@ metadata:
     app: sso
   name: keycloak
 spec:
-  http:
-    httpEnabled: true
-    tlsSecret: sso-x509-https-secret 
   externalAccess:
     enabled: true
   instances: 1


### PR DESCRIPTION
- startingCSV from the keycloak subscription to start installation always from HEAD that results in the shorten upgrade path
- remove `spec.http` field that is a feature of the v2alpha1 but not implemented in v1alpha1 (leads to warning)
```
 oc create --validate='warn' -f ~/git/sigstore-ocp/keycloak/resources/keycloack.yaml
Warning: unknown field "spec.http"
```
