### PR TITLE
Update CLI image refs

### DIFF
--- a/images/Dockerfile-clientserver
+++ b/images/Dockerfile-clientserver
@@ -1,6 +1,6 @@
-FROM quay.io/redhat-user-workloads/rhtas-tenant/rhtas-cli-1-0-beta/cosign@sha256:7c62ad9672ece28b44dc7abb61b055c30c8fd197b23ffa2437334ce0012a9322 AS cosign-image
-FROM quay.io/redhat-user-workloads/rhtas-tenant/rhtas-cli-1-0-beta/gitsign@sha256:f89115971b1ede4cfa5874f90c90c8c2d79de534fd84094b1a9e626c80394f1b AS gitsign-image
-FROM quay.io/redhat-user-workloads/rhtas-tenant/rhtas-cli-1-0-beta/rekor-cli@sha256:9b1cf84cf89e539350257d9b3914f92bb87263f078185c606ab5e4b8ea6af924 AS rekor-image
+FROM quay.io/redhat-user-workloads/rhtas-tenant/rhtas-cli-1-0-beta/cosign@sha256:eff28709f7377b48c8b61aae8e227060771b4d1ed8a0bbcc52d689b46595c494 AS cosign-image
+FROM quay.io/redhat-user-workloads/rhtas-tenant/rhtas-cli-1-0-beta/gitsign@sha256:62a3e34b0b918aaa60dc6a0647548ae89da3597121fcc4be8cb571fb89bbe278 AS gitsign-image
+FROM quay.io/redhat-user-workloads/rhtas-tenant/rhtas-cli-1-0-beta/rekor-cli@sha256:2e0287e5d37d32ef6751fc018573eb954456cd1c6227dfbc9ff5fcdcab59e07c
 
 FROM registry.redhat.io/rhel8/httpd-24:latest
 


### PR DESCRIPTION
Updates the image refs to the latest image refs from the rhtas-cli-1-0-beta-lhg9z
 snapshot.