### PR TITLE
fixup: restore rekor-image ref

### DIFF
--- a/images/Dockerfile-clientserver
+++ b/images/Dockerfile-clientserver
@@ -1,6 +1,6 @@
 FROM quay.io/redhat-user-workloads/rhtas-tenant/rhtas-cli-1-0-beta/cosign@sha256:eff28709f7377b48c8b61aae8e227060771b4d1ed8a0bbcc52d689b46595c494 AS cosign-image
 FROM quay.io/redhat-user-workloads/rhtas-tenant/rhtas-cli-1-0-beta/gitsign@sha256:62a3e34b0b918aaa60dc6a0647548ae89da3597121fcc4be8cb571fb89bbe278 AS gitsign-image
-FROM quay.io/redhat-user-workloads/rhtas-tenant/rhtas-cli-1-0-beta/rekor-cli@sha256:2e0287e5d37d32ef6751fc018573eb954456cd1c6227dfbc9ff5fcdcab59e07c
+FROM quay.io/redhat-user-workloads/rhtas-tenant/rhtas-cli-1-0-beta/rekor-cli@sha256:2e0287e5d37d32ef6751fc018573eb954456cd1c6227dfbc9ff5fcdcab59e07c AS rekor-image
 
 FROM registry.redhat.io/rhel8/httpd-24:latest
 


### PR DESCRIPTION
I inadvertently removed the `rekor-image` ref name in my last PR