### PR TITLE
chore(pipelines): bump buildah image

### DIFF
--- a/.tekton/client-server-pull-request.yaml
+++ b/.tekton/client-server-pull-request.yaml
@@ -230,7 +230,7 @@ spec:
         - name: name
           value: buildah
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1@sha256:f41166f57c7bf33f598d6c7436af8890c4d483419f4346e67037c7a5f850c367
+          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1@sha256:e38365a7acbe4a6135fa72096513e24795dc7a8ed8f6be5fa0c7bf0f30484ac6
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/client-server-push.yaml
+++ b/.tekton/client-server-push.yaml
@@ -227,7 +227,7 @@ spec:
         - name: name
           value: buildah
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1@sha256:f41166f57c7bf33f598d6c7436af8890c4d483419f4346e67037c7a5f850c367
+          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1@sha256:e38365a7acbe4a6135fa72096513e24795dc7a8ed8f6be5fa0c7bf0f30484ac6
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
This change addresses a bug in RHTAP where build pipeline output strings are required to be less than 4k. The previous buildah task was causing our client-server image build to fail.