### PR TITLE
chore: update image refs in build pipelines

### DIFF
--- a/.tekton/client-server-pull-request.yaml
+++ b/.tekton/client-server-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
       == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: rhtas-cli-1-0-beta
+    appstudio.openshift.io/application: rhtas-stack-1-0-beta
     appstudio.openshift.io/component: client-server
     pipelines.appstudio.openshift.io/type: build
   name: client-server-on-pull-request
@@ -25,7 +25,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtas-tenant/rhtas-cli-1-0-beta/client-server:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/rhtas-tenant/rhtas-stack-1-0-beta/client-server:on-pr-{{revision}}
   - name: path-context
     value: .
   - name: revision

--- a/.tekton/client-server-pull-request.yaml
+++ b/.tekton/client-server-pull-request.yaml
@@ -30,6 +30,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: prefetch-input
+    value: ''
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -200,10 +202,10 @@ spec:
           value: task
         resolver: bundles
       when:
-      - input: $(params.hermetic)
-        operator: in
+      - input: $(params.prefetch-input)
+        operator: notin
         values:
-        - "true"
+        - "{}"
       workspaces:
       - name: source
         workspace: workspace

--- a/.tekton/client-server-push.yaml
+++ b/.tekton/client-server-push.yaml
@@ -27,6 +27,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: prefetch-input
+    value: ''
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -197,10 +199,10 @@ spec:
           value: task
         resolver: bundles
       when:
-      - input: $(params.hermetic)
-        operator: in
+      - input: $(params.prefetch-input)
+        operator: notin
         values:
-        - "true"
+        - "{}"
       workspaces:
       - name: source
         workspace: workspace

--- a/.tekton/client-server-push.yaml
+++ b/.tekton/client-server-push.yaml
@@ -10,7 +10,7 @@ metadata:
       == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: rhtas-cli-1-0-beta
+    appstudio.openshift.io/application: rhtas-stack-1-0-beta
     appstudio.openshift.io/component: client-server
     pipelines.appstudio.openshift.io/type: build
   name: client-server-on-push
@@ -22,7 +22,7 @@ spec:
   - name: git-url
     value: '{{repo_url}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtas-tenant/rhtas-cli-1-0-beta/client-server:{{revision}}
+    value: quay.io/redhat-user-workloads/rhtas-tenant/rhtas-stack-1-0-beta/client-server:{{revision}}
   - name: path-context
     value: .
   - name: revision

--- a/images/Dockerfile-clientserver
+++ b/images/Dockerfile-clientserver
@@ -43,6 +43,8 @@ LABEL \
       name="trusted-artifact-signer-serve-cli-container" \
       version="0.0.1" \
       summary="Red Hat serves Trusted Artifact Signer CLI binaries" \
-      description="Serves Trusted Artifact Signer CLI binaries from server" \
+      description="Serves Trusted Artifact Signer CLI binaries from an HTTP server" \
+      io.k8s.description="Serves Trusted Artifact Signer CLI binaries from an HTTP server" \
       io.k8s.display-name="Red Hat serves Trusted Artifact Signer CLI binaries" \
+      io.openshift.tags="cosign, gitsign, rekor, cli, rhtas, trusted, artifact, signer, sigstore" \
       maintainer="trusted-artifact-signer@redhat.com"


### PR DESCRIPTION
This image moved from the CLI to the Stack application and therefore its image references need to be updated in the RHTAP pipelines.