### PR TITLE
pipelines: build source image on push

### DIFF
--- a/.tekton/client-server-push.yaml
+++ b/.tekton/client-server-push.yaml
@@ -29,6 +29,8 @@ spec:
     value: '{{revision}}'
   - name: prefetch-input
     value: ''
+  - name: build-source-image
+    value: 'true'
   pipelineSpec:
     finally:
     - name: show-sbom


### PR DESCRIPTION
Source image builds were only enabled for pull requests. This change also enables them on push.