### PR TITLE
Release 1.0.beta patch non certified images

### DIFF
--- a/charts/trusted-artifact-signer/README.md
+++ b/charts/trusted-artifact-signer/README.md
@@ -163,7 +163,7 @@ Kubernetes: `>= 1.19.0-0`
 | scaffold.ctlog.createctconfig.initContainerImage.curl.imagePullPolicy |  | string | `"IfNotPresent"` |
 | scaffold.ctlog.createctconfig.initContainerImage.curl.registry |  | string | `"registry.access.redhat.com"` |
 | scaffold.ctlog.createctconfig.initContainerImage.curl.repository |  | string | `"ubi9/ubi-minimal"` |
-| scaffold.ctlog.createctconfig.initContainerImage.curl.version |  | string | `"latest"` |
+| scaffold.ctlog.createctconfig.initContainerImage.curl.version |  | string | `"3e313209ac617a92b50350286752311d99ea2dafc429ef0e5311889294b0bc21"` |
 | scaffold.ctlog.createtree.displayName |  | string | `"ctlog-tree"` |
 | scaffold.ctlog.createtree.fullnameOverride |  | string | `"ctlog-createtree"` |
 | scaffold.ctlog.createtree.image.pullPolicy |  | string | `"IfNotPresent"` |

--- a/charts/trusted-artifact-signer/templates/tests/test-connection.yaml
+++ b/charts/trusted-artifact-signer/templates/tests/test-connection.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: curl
-      image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+      image: registry.access.redhat.com/ubi9/ubi-minimal@sha256:3e313209ac617a92b50350286752311d99ea2dafc429ef0e5311889294b0bc21
       command: ["/bin/sh", "-c"]
       args:
         - |

--- a/charts/trusted-artifact-signer/templates/tests/test-sign-verify.yaml
+++ b/charts/trusted-artifact-signer/templates/tests/test-sign-verify.yaml
@@ -9,12 +9,12 @@ metadata:
 spec:
     initContainers:
       - name: buildah
-        image: quay.io/buildah/stable
+        image: registry.redhat.io/rhel9/buildah@sha256:a65949e6654dee640634f2c86f7ec36ba9530f0e8160368d0711f2af2ee7587f
         command: ["/bin/sh", "-c"]
         args:
         - |
-            buildah pull alpine:latest
-            buildah tag alpine:latest ttl.sh/sigstore-test:5m
+            buildah pull alpine@sha256:48d9183eb12a05c99bcc0bf44a003607b8e941e1d4f41f9ad12bdcc4b5672f86
+            buildah tag alpine@sha256:48d9183eb12a05c99bcc0bf44a003607b8e941e1d4f41f9ad12bdcc4b5672f86 ttl.sh/sigstore-test:5m
             buildah push ttl.sh/sigstore-test:5m
         securityContext:
             privileged: true

--- a/charts/trusted-artifact-signer/values.schema.json
+++ b/charts/trusted-artifact-signer/values.schema.json
@@ -7,6 +7,9 @@
                     "properties": {
                         "namespace": {
                             "type": "string"
+                        },
+                        "namespace_create": {
+                            "type": "boolean"
                         }
                     }
                 },

--- a/charts/trusted-artifact-signer/values.schema.tmpl.json
+++ b/charts/trusted-artifact-signer/values.schema.tmpl.json
@@ -23,6 +23,9 @@
                     "properties": {
                         "namespace": {
                             "type": "string"
+                        },
+                        "namespace_create": {
+                            "type": "string"
                         }
                     }
                 },

--- a/charts/trusted-artifact-signer/values.yaml
+++ b/charts/trusted-artifact-signer/values.yaml
@@ -7,6 +7,7 @@ global:
 configs:
   sigstore_monitoring:
     namespace: sigstore-monitoring
+    create_namespace: false
   segment_backup_job:
     name: segment-backup-job
     namespace: sigstore-monitoring
@@ -238,6 +239,20 @@ scaffold:
       enabled: false
     redis:
       fullnameOverride: rekor-redis
+      args: []
+      image:
+        registry: registry.redhat.io
+        repository: rhel9/redis-6
+        version: "sha256:63da4136f2c8579a9e3971c8a335dd2bc1279e4afb15f5a8d63bf66c49f9c34a"
+        pullPolicy: IfNotPresent
+    initContainerImage:
+      curl:
+        registry: registry.access.redhat.com
+        repository: ubi9/ubi-minimal
+        version: "sha256:3e313209ac617a92b50350286752311d99ea2dafc429ef0e5311889294b0bc21"
+        imagePullPolicy: IfNotPresent
+
+
     server:
       fullnameOverride: rekor-server
       image:
@@ -294,19 +309,14 @@ scaffold:
       curl:
         registry: registry.access.redhat.com
         repository: ubi9/ubi-minimal
-        version: latest
+        version: "sha256:3e313209ac617a92b50350286752311d99ea2dafc429ef0e5311889294b0bc21"
         imagePullPolicy: IfNotPresent
     redis:
-      args:
-        - /usr/bin/run-redis
-        - --bind
-        - 0.0.0.0
-        - --appendonly
-        - "yes"
+      args: []
       image:
         registry: registry.redhat.io
         repository: rhel9/redis-6
-        version: "sha256:031a5a63611e1e6a9fec47492a32347417263b79ad3b63bcee72fc7d02d64c94"
+        version: "sha256:63da4136f2c8579a9e3971c8a335dd2bc1279e4afb15f5a8d63bf66c49f9c34a"
         pullPolicy: IfNotPresent
 
     logSigner:

--- a/grafana/resources/namespace.yaml
+++ b/grafana/resources/namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: sigstore-monitoring
+    app.kubernetes.io/managed-by: Helm
+    meta.helm.sh/release-name: trusted-artifact-signer
+    meta.helm.sh/release-namespace: trusted-artifact-signer
+  name: sigstore-monitoring
+spec:
+  finalizers:
+  - kubernetes

--- a/tas-easy-install.sh
+++ b/tas-easy-install.sh
@@ -102,7 +102,7 @@ if [[ -n $segment_backup_job ]]; then
     oc delete job $segment_backup_job -n sigstore-monitoring
 fi
 
-oc new-project sigstore-monitoring > /dev/null 2>&1
+oc apply -f ../grafana/resources/namespace.yaml
 
 pull_secret_exists=$(oc get secret pull-secret -n sigstore-monitoring --ignore-not-found=true)
 if [[ -n $pull_secret_exists ]]; then


### PR DESCRIPTION
Changes:
- `SHA` locking ubi9/ubi-minimal tag (best practice)
- Swapping `buildah` to certified image + `SHA`  lock  (best practice)
- sigstore monitoring namepsace issue:
     - namespace needs to exist for creation of pull-secret at time of `tas-easy-install.sh` but for the charts to get certified they also need to be able to stand on their own.
     - Solution: create namespace in `tas-easy-install.sh` and set `namespace_create` to `false` in the charts, and swap the value out for verification
- Overwrite upstream chart values for certified `curl` and `redis` images. Still waiting on: https://github.com/securesign/scaffolding/pull/125 for the correct image tag.