### PR TITLE
enabling prefetched deps and hermetic builds

### DIFF
--- a/.tekton/client-server-1-0-gamma-pull-request.yaml
+++ b/.tekton/client-server-1-0-gamma-pull-request.yaml
@@ -31,6 +31,10 @@ spec:
     value: images
   - name: revision
     value: '{{revision}}'
+  - name: prefetch-input
+    value: ''
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/client-server-1-0-gamma-push.yaml
+++ b/.tekton/client-server-1-0-gamma-push.yaml
@@ -27,6 +27,10 @@ spec:
     value: images
   - name: revision
     value: '{{revision}}'
+  - name: prefetch-input
+    value: ''
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/client-server-pull-request.yaml
+++ b/.tekton/client-server-pull-request.yaml
@@ -32,6 +32,8 @@ spec:
     value: '{{revision}}'
   - name: prefetch-input
     value: ''
+  - name: hermetic
+    value: "true"
   - name: build-source-image
     value: "true"
   pipelineSpec:

--- a/.tekton/client-server-push.yaml
+++ b/.tekton/client-server-push.yaml
@@ -29,6 +29,8 @@ spec:
     value: '{{revision}}'
   - name: prefetch-input
     value: ''
+  - name: hermetic
+    value: "true"
   - name: build-source-image
     value: 'true'
   pipelineSpec:


### PR DESCRIPTION
For push and pull request tekton manifests, `prefetch-input` was already enabled. Adding it for the gamma release component.
/cc @lance 
/cc @tommyd450 