### PR TITLE
allowing for disabling segment-backup-job for vanilla k8s enablement

### DIFF
--- a/charts/trusted-artifact-signer/Chart.yaml
+++ b/charts/trusted-artifact-signer/Chart.yaml
@@ -33,4 +33,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.28
+version: 0.1.29

--- a/charts/trusted-artifact-signer/templates/segment-backup-cronjob.yaml
+++ b/charts/trusted-artifact-signer/templates/segment-backup-cronjob.yaml
@@ -23,7 +23,6 @@ spec:
             serviceAccountName: segment-backup-job
             containers:
               - name: {{ .Values.configs.segment_backup_job.name }}
-                # image: "{{ .Values.configs.segment_backup_job.image.registry }}/{{ .Values.configs.segment_backup_job.image.repository }}/{{ .Values.configs.segment_backup_job.image.version }}"
                 image: "{{ .Values.configs.segment_backup_job.image.registry }}/{{ .Values.configs.segment_backup_job.image.repository }}@{{ .Values.configs.segment_backup_job.image.version }}"
                 command: ["/bin/bash",  "/opt/app-root/src/script.sh"]
                 env:
@@ -36,4 +35,4 @@ spec:
                   capabilities:
                     drop:
                     - ALL
-{{- end}}
+{{- end }}

--- a/charts/trusted-artifact-signer/templates/segment-backup-job-clusterrole.yaml
+++ b/charts/trusted-artifact-signer/templates/segment-backup-job-clusterrole.yaml
@@ -18,4 +18,4 @@ rules:
   verbs:
   - get
   - list 
-{{- end}}
+{{- end }}

--- a/charts/trusted-artifact-signer/templates/segment-backup-job-clusterrolebinding.yaml
+++ b/charts/trusted-artifact-signer/templates/segment-backup-job-clusterrolebinding.yaml
@@ -11,4 +11,4 @@ subjects:
 - kind: ServiceAccount
   name: segment-backup-job
   namespace: {{ .Values.configs.segment_backup_job.namespace }}
-{{- end}}
+{{- end }}

--- a/charts/trusted-artifact-signer/templates/segment-backup-job-sa.yaml
+++ b/charts/trusted-artifact-signer/templates/segment-backup-job-sa.yaml
@@ -6,4 +6,4 @@ metadata:
   namespace: {{ .Values.configs.segment_backup_job.namespace }}
 secrets:
 - name: pull-secret
-{{- end}}
+{{- end }}

--- a/charts/trusted-artifact-signer/templates/segment-backup-job.yaml
+++ b/charts/trusted-artifact-signer/templates/segment-backup-job.yaml
@@ -32,4 +32,4 @@ spec:
             capabilities:
               drop:
               - ALL
-{{- end}}
+{{- end }}

--- a/charts/trusted-artifact-signer/values.schema.tmpl.json
+++ b/charts/trusted-artifact-signer/values.schema.tmpl.json
@@ -27,6 +27,9 @@
                         "name": {
                             "type": "string"
                         },
+                        "enabled": {
+                            "type": "boolean"
+                        },
                         "namespace": {
                             "type" : "string"
                         },

--- a/charts/trusted-artifact-signer/values.yaml
+++ b/charts/trusted-artifact-signer/values.yaml
@@ -6,8 +6,8 @@ global:
 
 configs:
   segment_backup_job:
-    enabled: false
-    namespace_create: false
+    enabled: true
+    name: segment-backup-job
     image:
       registry: registry.redhat.io
       repository: rhtas-tech-preview/segment-backup-job-rhel9

--- a/examples/values-kind-sigstore.yaml
+++ b/examples/values-kind-sigstore.yaml
@@ -7,6 +7,8 @@
 # 'fulcio-secret-rh' and 'rekor-private-key'
 # For root & key requirements, see ../requirements-keys-certs.md
 configs:
+  segment_backup_job:
+    enabled: false
   clientserver:
     consoleDownload: false
     route: false


### PR DESCRIPTION
/cc @cooktheryan --> this should enable you to do vanilla k8s and kind development since the segment backup job is Openshift opinionated. Its still set to `true` by default in the [values.yaml](https://github.com/securesign/sigstore-ocp/compare/release-1.0.gamma...Gregory-Pereira:sigstore-ocp:release-1.0.gamma-enable-disabling-segment-job?expand=1#diff-2d6b48a1bb9f1a6c85f004022e0b5c9917a2d5c48a39ae211407ce7ba27eb0a8R11) which you may want to swap, but it should ignore that value anyway based on the [kind-values](https://github.com/securesign/sigstore-ocp/compare/release-1.0.gamma...Gregory-Pereira:sigstore-ocp:release-1.0.gamma-enable-disabling-segment-job?expand=1#diff-4b67ea79a69ab8136632c66d4dee9de7a0c218fbd087fdc217eaf004fc074a3fR10-R11). The reason I left it as default true is I dont want to merge anything into an actual release branch that disables it by default.