### PR TITLE
Add OIDC Configuration

### DIFF
--- a/tas-installer/cmd/install.go
+++ b/tas-installer/cmd/install.go
@@ -7,6 +7,7 @@ import (
 
 	"securesign/sigstore-ocp/tas-installer/internal/install"
 	"securesign/sigstore-ocp/tas-installer/pkg/certs"
+	"securesign/sigstore-ocp/tas-installer/pkg/oidc"
 	"securesign/sigstore-ocp/tas-installer/pkg/secrets"
 
 	"github.com/spf13/cobra"
@@ -19,6 +20,7 @@ const (
 var (
 	helmChartVersion string
 	helmValuesFile   string
+	oidcConfig       oidc.OIDCConfig
 )
 
 var installCmd = &cobra.Command{
@@ -68,7 +70,7 @@ func installTas(tasNamespace string) error {
 		},
 		func() error {
 			log.Print("installing helm chart")
-			if err := install.HandleHelmChartInstall(kc, tasNamespace, tasReleaseName, helmValuesFile, helmChartVersion); err != nil {
+			if err := install.HandleHelmChartInstall(kc, oidcConfig, tasNamespace, tasReleaseName, helmValuesFile, helmChartVersion); err != nil {
 				return err
 			}
 			return nil
@@ -85,6 +87,9 @@ func installTas(tasNamespace string) error {
 func init() {
 	installCmd.PersistentFlags().StringVar(&helmChartVersion, "chartVersion", "0.1.26", "Version of the Helm chart")
 	installCmd.PersistentFlags().StringVar(&helmValuesFile, "valuesFile", "", "Custom values file for chart configuration")
+	installCmd.PersistentFlags().StringVar(&oidcConfig.IssuerURL, "oidc-issuer-url", "", "Specify the OIDC issuer URL e.g for keycloak: https://[keycloak-domain]/auth/realms/[realm-name]")
+	installCmd.PersistentFlags().StringVar(&oidcConfig.ClientID, "oidc-client-id", "", "Specify the OIDC client ID")
+	installCmd.PersistentFlags().StringVar(&oidcConfig.Type, "oidc-type", "", "Specify the OIDC type")
 }
 
 func getFulcioSecretFiles() map[string]string {

--- a/tas-installer/internal/install/install.go
+++ b/tas-installer/internal/install/install.go
@@ -7,13 +7,14 @@ import (
 	"securesign/sigstore-ocp/tas-installer/pkg/certs"
 	"securesign/sigstore-ocp/tas-installer/pkg/helm"
 	"securesign/sigstore-ocp/tas-installer/pkg/kubernetes"
+	"securesign/sigstore-ocp/tas-installer/pkg/oidc"
 	"securesign/sigstore-ocp/tas-installer/pkg/secrets"
 	"securesign/sigstore-ocp/tas-installer/ui"
 	"time"
 )
 
-func HandleHelmChartInstall(kc *kubernetes.KubernetesClient, tasNamespace, tasReleaseName, helmValuesFile, helmChartVersion string) error {
-	if err := helm.InstallTrustedArtifactSigner(kc, tasNamespace, tasReleaseName, helmValuesFile, helmChartVersion); err != nil {
+func HandleHelmChartInstall(kc *kubernetes.KubernetesClient, oidcConfig oidc.OIDCConfig, tasNamespace, tasReleaseName, helmValuesFile, helmChartVersion string) error {
+	if err := helm.InstallTrustedArtifactSigner(kc, oidcConfig, tasNamespace, tasReleaseName, helmValuesFile, helmChartVersion); err != nil {
 		return err
 	}
 	return nil

--- a/tas-installer/pkg/helm/values-openshift.tmpl
+++ b/tas-installer/pkg/helm/values-openshift.tmpl
@@ -24,10 +24,17 @@ scaffold:
     config:
       contents:
         OIDCIssuers:
-          ? https://oauth2.sigstore.dev/auth
-          : IssuerURL: https://oauth2.sigstore.dev/auth
-            ClientID: sigstore
-            Type: email
+          {{- if .OIDCconfig.IssuerURL }}
+          {{ .OIDCconfig.IssuerURL }}:
+            IssuerURL: "{{ .OIDCconfig.IssuerURL }}"
+            ClientID: "{{ if .OIDCconfig.ClientID }}{{ .OIDCconfig.ClientID }}{{ else }}sigstore{{ end }}"
+            Type: "{{ if .OIDCconfig.Type }}{{ .OIDCconfig.Type }}{{ else }}email{{ end }}"
+          {{- else }}
+          "https://oauth2.sigstore.dev/auth":
+            IssuerURL: "https://oauth2.sigstore.dev/auth"
+            ClientID: "sigstore"
+            Type: "email"
+          {{- end }}
   rekor:
     server:
       ingress:

--- a/tas-installer/pkg/oidc/type.go
+++ b/tas-installer/pkg/oidc/type.go
@@ -1,0 +1,8 @@
+package oidc
+
+// defines the type for the OIDC provider
+type OIDCConfig struct {
+	IssuerURL string
+	ClientID  string
+	Type      string
+}


### PR DESCRIPTION
This pr allows for the configuration of an OIDC provider with the tas installer 

```
Installs Trusted Artifact Signer (TAS) on a Kubernetes cluster.

        This command performs a series of actions:
        1. Initializes the Kubernetes client to interact with your cluster
        2. Sets up necessary certificates
        3. Configures secrets
        4. Deploys TAS to openshift

Usage:
  tas-installer install [flags]

Flags:
      --chartVersion string      Version of the Helm chart (default "0.1.26")
  -h, --help                     help for install
      --oidc-client-id string    Specify the OIDC client ID
      --oidc-issuer-url string   Specify the OIDC issuer URL e.g for keycloak: https://[keycloak-domain]/auth/realms/[realm-name]
      --oidc-type string         Specify the OIDC type
      --valuesFile string        Custom values file for chart configuration

Global Flags:
      --kubeconfig string   Specify the kubeconfig path (default "/home/japower/.kube/config")
```

It adds three new flags to the installer --oidc-client-id, --oidc-issuer-url and --oidc-type