### PR TITLE
swapping in productized version of redis

### DIFF
--- a/charts/trusted-artifact-signer/Chart.yaml
+++ b/charts/trusted-artifact-signer/Chart.yaml
@@ -33,4 +33,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.37
+version: 0.1.38

--- a/charts/trusted-artifact-signer/values.yaml
+++ b/charts/trusted-artifact-signer/values.yaml
@@ -251,6 +251,12 @@ scaffold:
       enabled: false
     redis:
       fullnameOverride: rekor-redis
+      image:
+        registry: quay.io
+        repository: redhat-user-workloads/rhtas-tenant/trillian-1-0-gamma/redis-0-6
+        version: sha256:48719064261a186bd9eddb8a76bf3bafa124cd38b7384ecea9ba588fe6b9d807
+        pullPolicy: IfNotPresent
+      args: []
     server:
       fullnameOverride: rekor-server
       image:
@@ -310,17 +316,12 @@ scaffold:
         version: latest
         imagePullPolicy: IfNotPresent
     redis:
-      args:
-        - /usr/bin/run-redis
-        - --bind
-        - 0.0.0.0
-        - --appendonly
-        - "yes"
       image:
         registry: registry.redhat.io
         repository: rhtas-tech-preview/redis-trillian-rhel9
         version: sha256:acf920baf6ee1715c0c9d7ddf69867d331c589d3afa680048c508943078d9585
         pullPolicy: IfNotPresent
+      args: []
 
     logSigner:
       name: trillian-logsigner

--- a/charts/trusted-artifact-signer/values.yaml
+++ b/charts/trusted-artifact-signer/values.yaml
@@ -251,12 +251,17 @@ scaffold:
       enabled: false
     redis:
       fullnameOverride: rekor-redis
+      args:
+        - /usr/bin/run-redis
+        - --bind
+        - 0.0.0.0
+        - --appendonly
+        - "yes"
       image:
-        registry: quay.io
-        repository: redhat-user-workloads/rhtas-tenant/trillian-1-0-gamma/redis-0-6
-        version: sha256:48719064261a186bd9eddb8a76bf3bafa124cd38b7384ecea9ba588fe6b9d807
+        registry: registry.redhat.io
+        repository: rhtas-tech-preview/redis-trillian-rhel9
+        version: sha256:acf920baf6ee1715c0c9d7ddf69867d331c589d3afa680048c508943078d9585
         pullPolicy: IfNotPresent
-      args: []
     server:
       fullnameOverride: rekor-server
       image:


### PR DESCRIPTION
/cc @lance

After this change can no longer reproduce the rekor witness issue with gamma branch. Also including the fix for Fulcio deployment in installer script directly, as well as add a templating command to `tas-easy-install.sh`