### PR TITLE
feat: add kube config to helm

### DIFF
--- a/tas-installer/cmd/uninstall.go
+++ b/tas-installer/cmd/uninstall.go
@@ -25,7 +25,7 @@ func init() {
 
 func uninstallTas() error {
 	log.Print("uninstalling helm chart")
-	msg, err := uninstall.HandleHelmChartUninstall(tasNamespace, tasReleaseName)
+	msg, err := uninstall.HandleHelmChartUninstall(kc, tasNamespace, tasReleaseName)
 	if err != nil {
 		log.Print(err.Error())
 	} else {

--- a/tas-installer/internal/uninstall/uninstall.go
+++ b/tas-installer/internal/uninstall/uninstall.go
@@ -7,8 +7,8 @@ import (
 	"securesign/sigstore-ocp/tas-installer/pkg/kubernetes"
 )
 
-func HandleHelmChartUninstall(tasNamespace, tasReleaseName string) (string, error) {
-	info, err := helm.UninstallTrustedArtifactSigner(tasNamespace, tasReleaseName)
+func HandleHelmChartUninstall(kc *kubernetes.KubernetesClient, tasNamespace, tasReleaseName string) (string, error) {
+	info, err := helm.UninstallTrustedArtifactSigner(kc, tasNamespace, tasReleaseName)
 	if err != nil {
 		return "", err
 	}

--- a/tas-installer/pkg/kubernetes/client.go
+++ b/tas-installer/pkg/kubernetes/client.go
@@ -17,6 +17,7 @@ type KubernetesClient struct {
 	DynamicClientSet  dynamic.Interface
 	ClusterBaseDomain string
 	ClusterCommonName string
+	KubeConfigPath    string
 }
 
 func InitKubeClient(kubeConfigPath string) (*KubernetesClient, error) {
@@ -44,6 +45,7 @@ func InitKubeClient(kubeConfigPath string) (*KubernetesClient, error) {
 
 	kubeClient.ClusterBaseDomain = baseDomain
 	kubeClient.ClusterCommonName = "apps." + baseDomain
+	kubeClient.KubeConfigPath = kubeConfigPath
 
 	return kubeClient, nil
 }


### PR DESCRIPTION
Small pr to add the kube config path to helm, when working on a different issue I noticed when working with a hypershift-hosted openshift cluster it gives you a kube config file. When I tried to pass this in it would create some namespaces that are not handled by the helm chart, but would fail when it came to helm chart installation this is because helm was using the default path i.e './kube/config' still, this fixes that :) 