### PR TITLE
Update .gitignore, remove binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ keys-cert
 
 .idea
 
-tas-install
-pull-secret.json
+*tas-install*
+*pull-secret.json*


### PR DESCRIPTION
@cooktheryan 
@tommyd450 
`tas-install` binary was pushed to GH, I updated .gitignore & removed it
ptal!