### PR TITLE
Use oc image extract for the cli build to reduce the number of source images

### DIFF
--- a/images/Dockerfile-clientserver
+++ b/images/Dockerfile-clientserver
@@ -1,51 +1,63 @@
-FROM quay.io/redhat-user-workloads/rhtas-tenant/cli-1-0-gamma/cosign-cli-2-2@sha256:83e03294d6dfe8443762a735b2abb1171043cbfb93694a459e4432e520acf9a2 AS cosign-image
-FROM quay.io/redhat-user-workloads/rhtas-tenant/cli-1-0-gamma/gitsign-cli-0-8@sha256:b8fae228a3e6dd53bfae8f23d44c8e08b4997a62f429f416401657fd54024d83 AS gitsign-image
-FROM quay.io/redhat-user-workloads/rhtas-tenant/cli-1-0-gamma/rekor-cli-1-3@sha256:b94954f6f82d9e5743c368a974a9d96c640e1ca7ba985fd3a86df5a989b8dd12 AS rekor-image
 
-FROM registry.redhat.io/rhtas-tech-preview/ec-rhel9:1.0.alpha-1705963542@sha256:6aca9b2e9fde177d1398820b4b0609865dc2b0573c2d9e6d475e515a6a123f1c AS ec-image
+# An image with oc so we can run `oc image extract` to download the binaries
+FROM registry.redhat.io/openshift4/ose-tools-rhel8:v4.11.0-202401122348.p0.gbf40a6c.assembly.stream AS downloads
+
+ARG COSIGN_IMAGE=quay.io/redhat-user-workloads/rhtas-tenant/cli-1-0-gamma/cosign-cli-2-2@sha256:83e03294d6dfe8443762a735b2abb1171043cbfb93694a459e4432e520acf9a2
+ARG GITSIGN_IMAGE=quay.io/redhat-user-workloads/rhtas-tenant/cli-1-0-gamma/gitsign-cli-0-8@sha256:b8fae228a3e6dd53bfae8f23d44c8e08b4997a62f429f416401657fd54024d83
+ARG REKOR_IMAGE=quay.io/redhat-user-workloads/rhtas-tenant/cli-1-0-gamma/rekor-cli-1-3@sha256:b94954f6f82d9e5743c368a974a9d96c640e1ca7ba985fd3a86df5a989b8dd12
+ARG EC_IMAGE=quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-v01-alpha/cli-v01-alpha@sha256:6aca9b2e9fde177d1398820b4b0609865dc2b0573c2d9e6d475e515a6a123f1c
+
+RUN mkdir -p /downloads/cosign && \
+    mkdir -p /downloads/gitsign && \
+    mkdir -p /downloads/rekor && \
+    mkdir -p /downloads/ec
+
+RUN oc image extract ${COSIGN_IMAGE} --path /usr/local/bin/cosign*:/downloads/cosign && \
+    oc image extract ${GITSIGN_IMAGE} --path /usr/local/bin/gitsign_cli_*:/downloads/gitsign && \
+    oc image extract ${REKOR_IMAGE} --path /usr/local/bin/rekor_cli_*:/downloads/rekor && \
+    oc image extract ${EC_IMAGE} --path /usr/local/bin/ec_*:/downloads/ec
+
+# So we have a consistently named and gzipped file
+RUN gzip /downloads/cosign/cosign && \
+    mv /downloads/cosign/cosign.gz /downloads/cosign/cosign-linux-amd64.gz
 
 FROM registry.access.redhat.com/ubi9/httpd-24@sha256:965f7b03ae8f45228bad765ce47bc8956711e854213df0e4cee8623d51317b0a
 
-RUN mkdir -p /var/www/html/clients
-RUN mkdir -p /var/www/html/clients/darwin
-RUN mkdir -p /var/www/html/clients/linux
-RUN mkdir -p /var/www/html/clients/windows
+RUN mkdir -p /var/www/html/clients/darwin && \
+    mkdir -p /var/www/html/clients/linux && \
+    mkdir -p /var/www/html/clients/windows
 
+COPY --from=downloads /downloads/cosign/cosign-darwin-amd64.gz /var/www/html/clients/darwin
+COPY --from=downloads /downloads/cosign/cosign-darwin-arm64.gz /var/www/html/clients/darwin
+COPY --from=downloads /downloads/cosign/cosign-linux-amd64.gz /var/www/html/clients/linux
+COPY --from=downloads /downloads/cosign/cosign-linux-arm64.gz /var/www/html/clients/linux
+COPY --from=downloads /downloads/cosign/cosign-linux-ppc64le.gz /var/www/html/clients/linux
+COPY --from=downloads /downloads/cosign/cosign-linux-s390x.gz /var/www/html/clients/linux
+COPY --from=downloads /downloads/cosign/cosign-windows-amd64.gz /var/www/html/clients/windows
 
-COPY --from=cosign-image /usr/local/bin/cosign /var/www/html/clients/linux
-COPY --from=cosign-image /usr/local/bin/cosign-darwin-amd64.gz /var/www/html/clients/darwin
-COPY --from=cosign-image /usr/local/bin/cosign-darwin-arm64.gz /var/www/html/clients/darwin
-COPY --from=cosign-image /usr/local/bin/cosign-linux-arm64.gz /var/www/html/clients/linux
-COPY --from=cosign-image /usr/local/bin/cosign-linux-ppc64le.gz /var/www/html/clients/linux
-COPY --from=cosign-image /usr/local/bin/cosign-linux-s390x.gz /var/www/html/clients/linux
-COPY --from=cosign-image /usr/local/bin/cosign /var/www/html/clients/linux
-COPY --from=cosign-image /usr/local/bin/cosign-windows-amd64.gz /var/www/html/clients/windows
+COPY --from=downloads /downloads/gitsign/gitsign_cli_darwin_amd64.gz /var/www/html/clients/darwin
+COPY --from=downloads /downloads/gitsign/gitsign_cli_darwin_arm64.gz /var/www/html/clients/darwin
+COPY --from=downloads /downloads/gitsign/gitsign_cli_linux_amd64.gz /var/www/html/clients/linux
+COPY --from=downloads /downloads/gitsign/gitsign_cli_linux_arm64.gz /var/www/html/clients/linux
+COPY --from=downloads /downloads/gitsign/gitsign_cli_linux_ppc64le.gz /var/www/html/clients/linux
+COPY --from=downloads /downloads/gitsign/gitsign_cli_linux_s390x.gz /var/www/html/clients/linux
+COPY --from=downloads /downloads/gitsign/gitsign_cli_windows_amd64.exe.gz /var/www/html/clients/windows
 
-RUN gzip /var/www/html/clients/linux/cosign
+COPY --from=downloads /downloads/rekor/rekor_cli_darwin_amd64.gz /var/www/html/clients/darwin
+COPY --from=downloads /downloads/rekor/rekor_cli_darwin_arm64.gz /var/www/html/clients/darwin
+COPY --from=downloads /downloads/rekor/rekor_cli_linux_amd64.gz /var/www/html/clients/linux
+COPY --from=downloads /downloads/rekor/rekor_cli_linux_arm64.gz /var/www/html/clients/linux
+COPY --from=downloads /downloads/rekor/rekor_cli_linux_ppc64le.gz /var/www/html/clients/linux
+COPY --from=downloads /downloads/rekor/rekor_cli_linux_s390x.gz /var/www/html/clients/linux
+COPY --from=downloads /downloads/rekor/rekor_cli_windows_amd64.exe.gz /var/www/html/clients/windows
 
-COPY --from=gitsign-image /usr/local/bin/gitsign_cli_darwin_amd64.gz /var/www/html/clients/darwin
-COPY --from=gitsign-image /usr/local/bin/gitsign_cli_darwin_arm64.gz /var/www/html/clients/darwin
-COPY --from=gitsign-image /usr/local/bin/gitsign_cli_linux_amd64.gz /var/www/html/clients/linux
-COPY --from=gitsign-image /usr/local/bin/gitsign_cli_linux_arm64.gz /var/www/html/clients/linux
-COPY --from=gitsign-image /usr/local/bin/gitsign_cli_linux_ppc64le.gz /var/www/html/clients/linux
-COPY --from=gitsign-image /usr/local/bin/gitsign_cli_linux_s390x.gz /var/www/html/clients/linux
-COPY --from=gitsign-image /usr/local/bin/gitsign_cli_windows_amd64.exe.gz /var/www/html/clients/windows
-
-COPY --from=rekor-image /usr/local/bin/rekor_cli_darwin_amd64.gz /var/www/html/clients/darwin
-COPY --from=rekor-image /usr/local/bin/rekor_cli_darwin_arm64.gz /var/www/html/clients/darwin
-COPY --from=rekor-image /usr/local/bin/rekor_cli_linux_amd64.gz /var/www/html/clients/linux
-COPY --from=rekor-image /usr/local/bin/rekor_cli_linux_arm64.gz /var/www/html/clients/linux
-COPY --from=rekor-image /usr/local/bin/rekor_cli_linux_ppc64le.gz /var/www/html/clients/linux
-COPY --from=rekor-image /usr/local/bin/rekor_cli_linux_s390x.gz /var/www/html/clients/linux
-COPY --from=rekor-image /usr/local/bin/rekor_cli_windows_amd64.exe.gz /var/www/html/clients/windows
-
-COPY --from=ec-image /usr/local/bin/ec_darwin_amd64.gz /var/www/html/clients/darwin
-COPY --from=ec-image /usr/local/bin/ec_darwin_arm64.gz /var/www/html/clients/darwin
-COPY --from=ec-image /usr/local/bin/ec_linux_amd64.gz /var/www/html/clients/linux
-COPY --from=ec-image /usr/local/bin/ec_linux_arm64.gz /var/www/html/clients/linux
-COPY --from=ec-image /usr/local/bin/ec_linux_ppc64le.gz /var/www/html/clients/linux
-COPY --from=ec-image /usr/local/bin/ec_linux_s390x.gz /var/www/html/clients/linux
-COPY --from=ec-image /usr/local/bin/ec_windows_amd64.exe.gz /var/www/html/clients/windows
+COPY --from=downloads /downloads/ec/ec_darwin_amd64.gz /var/www/html/clients/darwin
+COPY --from=downloads /downloads/ec/ec_darwin_arm64.gz /var/www/html/clients/darwin
+COPY --from=downloads /downloads/ec/ec_linux_amd64.gz /var/www/html/clients/linux
+COPY --from=downloads /downloads/ec/ec_linux_arm64.gz /var/www/html/clients/linux
+COPY --from=downloads /downloads/ec/ec_linux_ppc64le.gz /var/www/html/clients/linux
+COPY --from=downloads /downloads/ec/ec_linux_s390x.gz /var/www/html/clients/linux
+COPY --from=downloads /downloads/ec/ec_windows_amd64.exe.gz /var/www/html/clients/windows
 
 RUN   mv /var/www/html/clients/darwin/gitsign_cli_darwin_amd64.gz /var/www/html/clients/darwin/gitsign-amd64.gz && \
       mv /var/www/html/clients/darwin/gitsign_cli_darwin_arm64.gz /var/www/html/clients/darwin/gitsign-arm64.gz && \
@@ -75,7 +87,7 @@ RUN mv /var/www/html/clients/darwin/cosign-darwin-amd64.gz /var/www/html/clients
       mv /var/www/html/clients/windows/cosign-windows-amd64.gz /var/www/html/clients/windows/cosign-amd64.gz && \
       mv /var/www/html/clients/darwin/cosign-darwin-arm64.gz /var/www/html/clients/darwin/cosign-arm64.gz && \
       mv /var/www/html/clients/linux/cosign-linux-ppc64le.gz /var/www/html/clients/linux/cosign-ppc64le.gz && \
-      mv /var/www/html/clients/linux/cosign.gz /var/www/html/clients/linux/cosign-amd64.gz && \
+      mv /var/www/html/clients/linux/cosign-linux-amd64.gz /var/www/html/clients/linux/cosign-amd64.gz && \
       mv /var/www/html/clients/linux/cosign-linux-s390x.gz /var/www/html/clients/linux/cosign-s390x.gz && \
       mv /var/www/html/clients/linux/cosign-linux-arm64.gz /var/www/html/clients/linux/cosign-arm64.gz
 


### PR DESCRIPTION
This avoids the BASE_IMAGE_DIGESTS Tekton task result in the Konflux build pipeline exceeding the maximum size and causing the build to fail.