### PR TITLE
Disable hermetic builds for cli image workaround

### DIFF
--- a/.tekton/client-server-1-0-gamma-pull-request.yaml
+++ b/.tekton/client-server-1-0-gamma-pull-request.yaml
@@ -34,7 +34,9 @@ spec:
   - name: prefetch-input
     value: ''
   - name: hermetic
-    value: "true"
+    # Temporary workaround related to https://github.com/securesign/sigstore-ocp/pull/160
+    value: "false"
+    # value: "true"
   - name: build-source-image
     value: "true"
   pipelineSpec:

--- a/.tekton/client-server-1-0-gamma-push.yaml
+++ b/.tekton/client-server-1-0-gamma-push.yaml
@@ -30,7 +30,9 @@ spec:
   - name: prefetch-input
     value: ''
   - name: hermetic
-    value: "true"
+    # Temporary workaround related to https://github.com/securesign/sigstore-ocp/pull/160
+    value: "false"
+    # value: "true"
   - name: build-source-image
     value: "true"
   pipelineSpec:


### PR DESCRIPTION
In the #160 PR the binary cli tools are fetched using `ec image extract`, hence we'll need the buildah task to allow network access.

This should be reverted once we have a better solution for the "too many base images overflow tekton task result" problem.