### PR TITLE
Add readme on client server cli source container

### DIFF
--- a/images/sources-readme.txt
+++ b/images/sources-readme.txt
@@ -1,0 +1,7 @@
+
+Due to the way this image is built, the source container for the image itself
+does not include the full set of sources for the cli tool binaries included in
+the image, i.e. `cosign`, `gitsign`, `rekor-cli` and `ec`.
+
+The complete sources for each cli tool are available in the source containers
+for the images that the binaries are extracted from.


### PR DESCRIPTION
Since the `oc image extract` technique introduced in #160 has the side-effect of the automatically generated source container not including all the sources for each binary, lets add a readme file to explain where to look for the additional source containers.