### PR TITLE
Generate script without escape characters and indentation

### DIFF
--- a/tas-installer/cmd/envgen.go
+++ b/tas-installer/cmd/envgen.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -39,25 +40,27 @@ func generateEnvVars() error {
 		echo "Base hostname = $BASE_HOSTNAME"
 		
 		export KEYCLOAK_REALM=sigstore
-		export KEYCLOAK_URL=https://keycloak-keycloak-system.\` + baseHostname + `
-		export TUF_URL=https://tuf.\` + baseHostname + `
-		export COSIGN_FULCIO_URL=https://fulcio.\` + baseHostname + `
-		export COSIGN_REKOR_URL=https://rekor.\` + baseHostname + `
-		export COSIGN_MIRROR=\https://tuf.\` + baseHostname + `
-		export COSIGN_ROOT=\https://tuf.\` + baseHostname + `/root.json
-		export COSIGN_OIDC_ISSUER=\https://keycloak-keycloak-system.\` + baseHostname + `/auth/realms/\sigstore
-		export COSIGN_CERTIFICATE_OIDC_ISSUER=\https://keycloak-keycloak-system.\` + baseHostname + `/auth/realms/\sigstore
+		export KEYCLOAK_URL=https://keycloak-keycloak-system.` + baseHostname + `
+		export TUF_URL=https://tuf.` + baseHostname + `
+		export COSIGN_FULCIO_URL=https://fulcio.` + baseHostname + `
+		export COSIGN_REKOR_URL=https://rekor.` + baseHostname + `
+		export COSIGN_MIRROR=https://tuf.` + baseHostname + `
+		export COSIGN_ROOT=https://tuf.` + baseHostname + `/root.json
+		export COSIGN_OIDC_ISSUER=https://keycloak-keycloak-system.` + baseHostname + `/auth/realms/sigstore
+		export COSIGN_CERTIFICATE_OIDC_ISSUER=https://keycloak-keycloak-system.` + baseHostname + `/auth/realms/sigstore
 		export COSIGN_YES="true"
 
 		# Gitsign/Sigstore Variables
-		export SIGSTORE_FULCIO_URL=\https://fulcio.\` + baseHostname + `
-		export SIGSTORE_OIDC_ISSUER=\https://keycloak-keycloak-system.\` + baseHostname + `/auth/realms/\sigstore
-		export SIGSTORE_REKOR_URL=\https://rekor.\` + baseHostname + `
+		export SIGSTORE_FULCIO_URL=https://fulcio.` + baseHostname + `
+		export SIGSTORE_OIDC_ISSUER=https://keycloak-keycloak-system.` + baseHostname + `/auth/realms/sigstore
+		export SIGSTORE_REKOR_URL=https://rekor.` + baseHostname + `
 
 		# Rekor CLI Variables
-		export REKOR_REKOR_SERVER=\https://rekor.\` + baseHostname + `
+		export REKOR_REKOR_SERVER=https://rekor.` + baseHostname + `
 		`
-		
+	scriptContent = strings.Replace(scriptContent, "\t\t", "", -1)
+	scriptContent = strings.TrimSpace(scriptContent)
+
 	fileName := "tas-env-variables.sh"
 	file, err := os.Create(fileName)
 	if err != nil {


### PR DESCRIPTION
Generated script works, but contains unnecessary escape characters and indentation.
Part of it:
```

		#!/bin/bash
		export BASE_HOSTNAME=apps.rosa.ji22z-8ghaf-n5s.4l1r.p3.openshiftapps.com
		echo "Base hostname = $BASE_HOSTNAME"

		export COSIGN_MIRROR=\https://tuf.\apps.rosa.ji22z-8ghaf-n5s.4l1r.p3.openshiftapps.com
		export COSIGN_ROOT=\https://tuf.\apps.rosa.ji22z-8ghaf-n5s.4l1r.p3.openshiftapps.com/root.json
		export COSIGN_OIDC_ISSUER=\https://keycloak-keycloak-system.\apps.rosa.ji22z-8ghaf-n5s.4l1r.p3.openshiftapps.com/auth/realms/\sigstore
		export REKOR_REKOR_SERVER=\https://rekor.\apps.rosa.ji22z-8ghaf-n5s.4l1r.p3.openshiftapps.com
```
This was removed.