### PR TITLE
feat(config): add configmap for rekor endpoint

### DIFF
--- a/charts/trusted-artifact-signer/templates/rekor-ui-deployment.yaml
+++ b/charts/trusted-artifact-signer/templates/rekor-ui-deployment.yaml
@@ -26,10 +26,7 @@ spec:
         imagePullPolicy: Always
         env:
         - name: NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN
-          valueFrom:
-            configMapKeyRef:
-              name: rekor-ui-default-domain-config
-              key: NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN
+          value: "https://rekor/.{{ .Values.global.appsSubdomain }}"
         ports:
           - containerPort: 3000
             protocol: TCP

--- a/charts/trusted-artifact-signer/templates/rekor-ui-deployment.yaml
+++ b/charts/trusted-artifact-signer/templates/rekor-ui-deployment.yaml
@@ -25,8 +25,11 @@ spec:
         image: "{{ template "image" .Values.configs.rekorui.image }}"
         imagePullPolicy: Always
         env:
-        - name: REKORDOMAIN
-          value:  {{ .Values.configs.rekorui.rekordomain }}
+        - name: NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN
+          valueFrom:
+            configMapKeyRef:
+              name: rekor-ui-default-domain-config
+              key: NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN
         ports:
           - containerPort: 3000
             protocol: TCP


### PR DESCRIPTION
This PR adds reference to a ConfigMap with the required environment variable in order for the `rekor-search-ui` to be able to issue requests to the Rekor server.